### PR TITLE
Fix bug with ignored options in initialization.

### DIFF
--- a/lib/guard/haml.rb
+++ b/lib/guard/haml.rb
@@ -7,10 +7,10 @@ module Guard
   class Haml < Guard
     
     def initialize(watchers = [], options = {})
-      super(watchers, {
-        :notifications => true      
-      }.merge(options))
-      @watchers, @options = watchers, options
+      @options = {
+        :notifications => true
+      }.merge(options)
+      super(watchers, @options)
     end
     
     def compile_haml file


### PR DESCRIPTION
When I was using this gem, I noticed that my Growl wasn't notifying me. I looked in the code and saw that it depended on `@options[:notifications]`. In `Haml#initialize`, it looked like it was trying to default that option to true, but it was only using it to pass through to `super`, and not to the `@options` instance variable. I changed that. Now Growl notifications work. All specs pass.
