### PR TITLE
Allow multiple outputs

### DIFF
--- a/lib/guard/haml.rb
+++ b/lib/guard/haml.rb
@@ -34,11 +34,13 @@ module Guard
 
     def run_on_changes(paths)
       paths.each do |file|
-        output_file = get_output(file)
-        FileUtils.mkdir_p File.dirname(output_file)
-        File.open(output_file, 'w') { |f| f.write(compile_haml(file)) }
+        output_files = get_output(file)
+        output_files.each do |output_file|
+          FileUtils.mkdir_p File.dirname(output_file)
+          File.open(output_file, 'w') { |f| f.write(compile_haml(file)) }
+        end
         message = "Successfully compiled haml to html!\n"
-        message += "# #{file} → #{output_file}".gsub("#{Bundler.root.to_s}/", '')
+        message += "# #{file} → #{output_files.join(', ')}".gsub("#{Bundler.root.to_s}/", '')
         ::Guard::UI.info message
         Notifier.notify( true, message ) if @options[:notifications]
       end
@@ -63,22 +65,24 @@ module Guard
     # Get the file path to output the html based on the file being
     # built. The output path is relative to where guard is being run.
     #
-    # @param file [String] path to file being built
-    # @return [String] path to file where output should be written
+    # @param file [String, Array<String>] path to file being built
+    # @return [Array<String>] path(s) to file where output should be written
     #
-    def get_output(file)
-      file_dir = File.dirname(file)
-      file_name = File.basename(file).split('.')[0..-2].join('.')
+    def get_output(files)
+      Array(files).map do |file|
+        file_dir = File.dirname(file)
+        file_name = File.basename(file).split('.')[0..-2].join('.')
 
-      file_name = "#{file_name}.html" if file_name.match("\.html?").nil?
+        file_name = "#{file_name}.html" if file_name.match("\.html?").nil?
 
-      file_dir = file_dir.gsub(Regexp.new("#{@options[:input]}(\/){0,1}"), '') if @options[:input]
-      file_dir = File.join(@options[:output], file_dir) if @options[:output]
+        file_dir = file_dir.gsub(Regexp.new("#{@options[:input]}(\/){0,1}"), '') if @options[:input]
+        file_dir = File.join(@options[:output], file_dir) if @options[:output]
 
-      if file_dir == ''
-        file_name
-      else
-        File.join(file_dir, file_name)
+        if file_dir == ''
+          file_name
+        else
+          File.join(file_dir, file_name)
+        end
       end
     end
 

--- a/spec/fixtures/test2.html.haml
+++ b/spec/fixtures/test2.html.haml
@@ -1,0 +1,9 @@
+!!!
+%html(lang="en")
+  %head
+    %meta(charset="utf-8")
+    %title Guard::Haml
+  %body
+    .content
+      %h1 Welcome to Guard::Haml
+      %p Testing

--- a/spec/guard/haml_spec.rb
+++ b/spec/guard/haml_spec.rb
@@ -77,19 +77,24 @@ describe Guard::Haml do
 
   describe '#get_output' do
     context 'by default' do
-      it 'should return test/index.html.haml as test/index.html' do
+      it 'should return test/index.html.haml as [test/index.html]' do
         subject.send(:get_output, 'test/index.html.haml').
-                        should eq('test/index.html')
+                        should eq(['test/index.html'])
       end
 
-      it 'should return test/index.htm.haml as test/index.htm' do
+      it 'should return test/index.htm.haml as [test/index.htm]' do
         subject.send(:get_output, 'test/index.htm.haml').
-                        should eq('test/index.htm')
+                        should eq(['test/index.htm'])
       end
 
-      it 'should return test/index.haml as test/index.html' do
+      it 'should return test/index.haml as [test/index.html]' do
         subject.send(:get_output, 'test/index.haml').
-                        should eq('test/index.html')
+                        should eq(['test/index.html'])
+      end
+
+      it 'should return [test/index1.html.haml, test/index2.html.haml] as [test/index1.html, test/index2.html]' do
+        subject.send(:get_output, ['test/index1.html.haml', 'test/index2.html.haml']).
+                        should eq(['test/index1.html', 'test/index2.html'])
       end
     end
 
@@ -98,9 +103,9 @@ describe Guard::Haml do
         subject.options[:output] = 'demo/output'
       end
 
-      it 'should return test/index.html.haml as demo/output/test/index.html.haml' do
+      it 'should return test/index.html.haml as [demo/output/test/index.html.haml]' do
         subject.send(:get_output, 'test/index.html.haml').
-                  should eq('demo/output/test/index.html')
+                  should eq(['demo/output/test/index.html'])
       end
     end
 
@@ -109,9 +114,9 @@ describe Guard::Haml do
         subject.options[:input] = 'test/ignore'
       end
 
-      it 'should return test/ignore/index.html.haml as index.html' do
+      it 'should return test/ignore/index.html.haml as [index.html]' do
         subject.send(:get_output, 'test/ignore/index.html.haml').
-                                    should eq('index.html')
+                                    should eq(['index.html'])
       end
 
       context 'when the output option is set to "demo/output"' do
@@ -119,9 +124,9 @@ describe Guard::Haml do
           subject.options[:output] = 'demo/output'
         end
 
-        it 'should return test/ignore/abc/index.html.haml as demo/output/abc/index.html' do
+        it 'should return test/ignore/abc/index.html.haml as [demo/output/abc/index.html]' do
           subject.send(:get_output, 'test/ignore/abc/index.html.haml').
-                          should eq('demo/output/abc/index.html')
+                          should eq(['demo/output/abc/index.html'])
         end
       end
     end
@@ -134,15 +139,35 @@ describe Guard::Haml do
     end
 
     context 'when notifications option set to true' do
-      after do
-        File.unlink "#{@fixture_path}/test.html"
+      let(:success_message) { "Successfully compiled haml to html!\n" }
+
+      context 'with one output' do
+        after do
+          File.unlink "#{@fixture_path}/test.html"
+        end
+
+        it 'should call Notifier.notify with 1 output' do
+          message = success_message + "# spec/fixtures/test.html.haml → spec/fixtures/test.html"
+          notifier.should_receive(:notify).with(true, message)
+          subject_notifiable.run_on_changes(["#{@fixture_path}/test.html.haml"])
+        end
       end
 
-      it 'should call Notifier.notify' do
-        message = "Successfully compiled haml to html!\n"
-        message += "# spec/fixtures/test.html.haml → spec/fixtures/test.html"
-        notifier.should_receive(:notify).with(true, message)
-        subject_notifiable.run_on_changes(["#{@fixture_path}/test.html.haml"])
+      context 'with two outputs' do
+        before do
+          subject_notifiable.stub(:get_output).and_return(["#{@fixture_path}/test.html", "#{@fixture_path}/test2.html"])
+        end
+
+        after do
+          File.unlink "#{@fixture_path}/test.html"
+          File.unlink "#{@fixture_path}/test2.html"
+        end
+
+        it 'should call Notifier.notify with 2 outputs' do
+          message = success_message + "# spec/fixtures/test.html.haml → spec/fixtures/test.html, spec/fixtures/test2.html"
+          notifier.should_receive(:notify).with(true, message)
+          subject_notifiable.run_on_changes(["#{@fixture_path}/test.html.haml"])
+        end
       end
     end
   end


### PR DESCRIPTION
This lets you compile to two (or more) html files from one haml file. My use case is that I want to compile to both a dev and prod build directory, so I would do something like this:

``` ruby
guard 'haml', { :input => 'markup', :output => ['public/dev', 'public/build'] } do
  watch(%r{^.+(\.haml)$})
end
```

Wrote new specs, passes in 1.8.7 and 1.9.2. Thanks!
