### PR TITLE
Use dumb '->' instead of encoded arrow for simplicity's sake

### DIFF
--- a/lib/guard/haml.rb
+++ b/lib/guard/haml.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'guard'
 require 'guard/guard'
 require 'guard/watcher'
@@ -38,7 +36,7 @@ module Guard
         FileUtils.mkdir_p File.dirname(output_file)
         File.open(output_file, 'w') { |f| f.write(compile_haml(file)) }
         message = "Successfully compiled haml to html!\n"
-        message += "# #{file} → #{output_file}".gsub("#{Bundler.root.to_s}/", '')
+        message += "# #{file} -> #{output_file}".gsub("#{Bundler.root.to_s}/", '')
         ::Guard::UI.info message
         Notifier.notify( true, message ) if @options[:notifications]
       end

--- a/spec/guard/haml_spec.rb
+++ b/spec/guard/haml_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe Guard::Haml do
@@ -140,7 +138,7 @@ describe Guard::Haml do
 
       it 'should call Notifier.notify' do
         message = "Successfully compiled haml to html!\n"
-        message += "# spec/fixtures/test.html.haml → spec/fixtures/test.html"
+        message += "# spec/fixtures/test.html.haml -> spec/fixtures/test.html"
         notifier.should_receive(:notify).with(true, message)
         subject_notifiable.run_on_changes(["#{@fixture_path}/test.html.haml"])
       end


### PR DESCRIPTION
When running `bundle exec guard`, I get the following error:

```
ERROR: Guard::Haml failed to achieve its <start>, exception was:
Encoding::UndefinedConversionError: U+2192 from UTF-8 to US-ASCII
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/ui.rb:23:in `write'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/ui.rb:23:in `puts'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/ui.rb:23:in `info'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bundler/gems/guard-haml-c79884f21b6e/lib/guard/haml.rb:42:in `block in run_on_changes'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bundler/gems/guard-haml-c79884f21b6e/lib/guard/haml.rb:36:in `each'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bundler/gems/guard-haml-c79884f21b6e/lib/guard/haml.rb:36:in `run_on_changes'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bundler/gems/guard-haml-c79884f21b6e/lib/guard/haml.rb:32:in `run_all'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bundler/gems/guard-haml-c79884f21b6e/lib/guard/haml.rb:20:in `start'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:95:in `block in run_supervised_task'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:93:in `catch'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:93:in `run_supervised_task'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:51:in `block in run'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:166:in `block (3 levels) in scoped_guards'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:165:in `each'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:165:in `block (2 levels) in scoped_guards'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:164:in `catch'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:164:in `block in scoped_guards'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:163:in `each'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:163:in `scoped_guards'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/runner.rb:50:in `run'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard.rb:159:in `block in start'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard.rb:324:in `block in within_preserved_state'
<internal:prelude>:10:in `synchronize'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard.rb:321:in `within_preserved_state'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard.rb:158:in `start'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/lib/guard/cli.rb:104:in `start'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.16.0/lib/thor.rb:275:in `dispatch'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.16.0/lib/thor/base.rb:425:in `start'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/gems/guard-1.4.0/bin/guard:6:in `<top (required)>'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bin/guard:23:in `load'
/Users/jgary/.rvm/gems/ruby-1.9.3-p194/bin/guard:23:in `<main>'
```

This is after having to paste the following at the top of my Gemfile to get `bundle install` working:

``` ruby
if RUBY_VERSION =~ /1.9/
  Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
end
```

Even after pasting that snippet in my Guardfile I still got that error.

I recommend changing &rarr; to ->, just for simplicity's sake, unless there's some obvious fix I'm missing.
