### PR TITLE
Added a coffeescript guard style error output.

### DIFF
--- a/lib/guard/haml.rb
+++ b/lib/guard/haml.rb
@@ -64,7 +64,7 @@ module Guard
         engine  = ::Haml::Engine.new(content, (@options[:haml_options] || {}))
         engine.render
       rescue StandardError => error
-        message = " # HAML compilation failed!\nError: #{error.message}"
+        message = "HAML compilation failed!\nError: #{error.message}"
         ::Guard::UI.error message
         Notifier.notify( false, message ) if @options[:notifications]
         raise message


### PR DESCRIPTION
I also use coffescritpt guard, one of the features the have is outputting errors directly to the supposed file. So I added `:error_to_haml` option that allows user to specify the following in the Guard file:

```
:error_to_haml => true
```

in this case and all Haml errors will be routed to the output file. Otherwise it will behave the same way.
