### PR TITLE
Fix bug in multiple `output` params

### DIFF
--- a/spec/guard/haml_spec.rb
+++ b/spec/guard/haml_spec.rb
@@ -89,11 +89,6 @@ describe Guard::Haml do
         subject.send(:get_output, 'test/index.haml').
                         should eq(['test/index.html'])
       end
-
-      it 'should return [test/index1.html.haml, test/index2.html.haml] as [test/index1.html, test/index2.html]' do
-        subject.send(:get_output, ['test/index1.html.haml', 'test/index2.html.haml']).
-                        should eq(['test/index1.html', 'test/index2.html'])
-      end
     end
 
     context 'when the output option is set to "demo/output"' do
@@ -104,6 +99,17 @@ describe Guard::Haml do
       it 'should return test/index.html.haml as [demo/output/test/index.html.haml]' do
         subject.send(:get_output, 'test/index.html.haml').
                   should eq(['demo/output/test/index.html'])
+      end
+    end
+
+    context 'when the output option is set to ["demo/output", "demo2/output"]' do
+      before do
+        subject.options[:output] = ['demo1/output', 'demo2/output']
+      end
+
+      it 'should return test/index.html.haml as [demo1/output/test/index.html.haml, demo2/output/test/index.html.haml]' do
+        subject.send(:get_output, 'test/index.html.haml').
+                  should eq(['demo1/output/test/index.html', 'demo2/output/test/index.html'])
       end
     end
 


### PR DESCRIPTION
Bug: https://github.com/manufaktor/guard-haml/pull/8#issuecomment-10268087

> @jamesgary I'm trying to fix an issue here before I release 0.5. In my case it builds the output directories inside each other. With your example setup, it creates the public/build inside public/dev, so the fullpath is public/dev/public/build which wasn't quite my expectation of this feature :-)

I had written the specs wrong (I had gotten my inputs and outputs mixed up), so this rectifies the situation. Thanks for catching it.
