### PR TITLE
Add file path to compilation error message

### DIFF
--- a/lib/guard/haml.rb
+++ b/lib/guard/haml.rb
@@ -64,7 +64,7 @@ module Guard
         engine  = ::Haml::Engine.new(content, (options[:haml_options] || {}))
         engine.render
       rescue StandardError => error
-        message = "HAML compilation failed!\nError: #{error.message}"
+        message = "HAML compilation of #{file} failed!\nError: #{error.message}"
         ::Guard::UI.error message
         Notifier.notify(false, message) if options[:notifications]
         throw :task_has_failed

--- a/spec/guard/haml_spec.rb
+++ b/spec/guard/haml_spec.rb
@@ -253,7 +253,7 @@ describe Guard::Haml do
 
     context 'when notifications option set to true' do
       it 'should call Notifier.notify when an error occurs' do
-        message = "HAML compilation failed!\n"
+        message = "HAML compilation of #{@fixture_path}/fail_test.html.haml failed!\n"
         message += "Error: Illegal nesting: content can't be both given on the same line as %p and nested within it."
         notifier.should_receive(:notify).with(false, message)
         catch(:task_has_failed) do


### PR DESCRIPTION
Just a minor change to specify where the compilation error occurred.
