### PR TITLE
Pass template filename to Haml

### DIFF
--- a/lib/guard/haml.rb
+++ b/lib/guard/haml.rb
@@ -56,7 +56,9 @@ module Guard
 
     def compile_haml(file)
       content = File.new(file).read
-      engine  = ::Haml::Engine.new(content, (options[:haml_options] || {}))
+      template_options = options[:haml_options] ? options[:haml_options].dup : {}
+      template_options[:filename] = file
+      engine  = ::Haml::Engine.new(content, template_options)
       engine.render scope_object
     rescue StandardError => error
       message = "HAML compilation of #{file} failed!\nError: #{error.message}"

--- a/spec/fixtures/filename.html.haml
+++ b/spec/fixtures/filename.html.haml
@@ -1,0 +1,2 @@
+__FILE__ = #{File.expand_path(__FILE__)}
+__dir__ = #{File.expand_path(__dir__)}

--- a/spec/guard/haml_spec.rb
+++ b/spec/guard/haml_spec.rb
@@ -278,5 +278,11 @@ RSpec.describe Guard::Haml do
         end).to be_nil
       end
     end
+
+    it 'correctly resolves __FILE__ and __dir__' do
+      html = subject.send(:compile_haml, "#{@fixture_path}/filename.html.haml")
+      expect(html).to match(%r{__FILE__ = #{@fixture_path}/filename\.html})
+      expect(html).to match(/__dir__ = #{@fixture_path}/)
+    end
   end
 end


### PR DESCRIPTION
Using the `:filename` option to Haml to pass the correct template filename allows correct handling of `__FILE__` and `__dir__` for relative file paths in the templates.

See http://stackoverflow.com/questions/38989394/render-a-relative-haml-using-guard for what prompted this PR.

I’ve changed the code to call `dup` on the options hash, since it is now being changed for each template. I think this is safer.

Also, I’m not too familiar with RSpec. I think the tests are right (they fail without the new code and pass with it) but if there’s something amiss let me know.
